### PR TITLE
feat: add Docker container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,29 @@
+# Git-related
 .git
 .gitignore
+
+# IDE / Editor files
+.vscode
+.idea
+
+# OS-specific junk
 **/.DS_Store
-**/node_modules
+Thumbs.db
+
+# Build artifacts
 **/bin
 **/obj
-**/*.log
+*.exe
+*.out
+*.log
+
+# Temporary or cache files
+*.tmp
+*.swp
+
+# Docker-specific
+Dockerfile
+
+
+# Database (optional — comment this out if you want to copy it into the image)
+#internal/db/whoknows.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,15 @@ FROM golang:1.25 AS build
 WORKDIR /app
 
 # Hent Go-moduler først (cache)
-COPY rewrite/go.mod rewrite/go.sum ./
+
+COPY go.mod go.sum ./
 RUN go mod download
 
 # Kopiér app-kilde
-COPY rewrite/ .
+COPY . .
 
 # Byg statisk binær (CGO fri -> nem container)
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o app ./cmd/server
 
 ############################
 # Runtime (lille image)
@@ -29,11 +30,12 @@ COPY --from=build /app/static /app/static
 
 # Demo: tag din SQLite-db med i imaget
 # (Hvis jeres lærer hellere vil have ekstern DB, kan vi ændre det senere)
-COPY whoknows.db /app/whoknows.db
+COPY internal/db/whoknows.db /app/whoknows.db
 
 # Miljøvariabler (din main.go læser disse)
 ENV PORT=8080
 ENV DATABASE_PATH=/app/whoknows.db
+
 
 EXPOSE 8080
 USER nonroot:nonroot


### PR DESCRIPTION
## What
- Added Dockerfile and .dockerignore for containerizing the Go app.
- Includes SQLite database inside the image for easy testing.
- Uses multi-stage build with distroless runtime for minimal size.

## Why
- Enables consistent environment across all developers and deployment to VM.

## How
- Build with `docker build -t devops-app .`
- Run with `docker run -p 8080:8080 devops-app`

## Checklist
- [x] Builds locally
- [x] Runs on localhost:8080
- [x] Includes SQLite DB
