### PR TITLE
Add Docker build pipeline to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,28 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: Dockerfile
+  docker-build:
+    needs: [build, hadolint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/whoknows-app:latest


### PR DESCRIPTION
This PR extends the existing CI pipeline to include automated Docker image building and pushing.

Added a new job docker-build to .github/workflows/ci.yml.

The job builds the Go application using the Dockerfile and pushes the image to GitHub Container Registry (ghcr.io).

This allows the team to easily deploy the latest version of the app without manually building the image on the VM.

This change improves the DevOps flow by integrating continuous delivery into the existing CI setup.