### PR TITLE
Refactor Dockerfile and add docker-compose for persistent DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  whoknows-app:
+    build: .
+    container_name: whoknows-app
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080
+      - DATABASE_PATH=/app/data/seed/whoknows.db
+      - SEED_ON_BOOT=1   # Only needed the first time to seed data
+    volumes:
+      # Mount a local folder to persist database data
+      - ./data:/app/data
+    restart: unless-stopped


### PR DESCRIPTION
# Refactor Dockerfile and Add Docker Compose Setup

## Description
- Replaced Distroless runtime image with `alpine:latest` for easier debugging and development.
- Removed pre-baked SQLite database; the app now initializes and seeds the DB at runtime.
- Added `docker-compose.yml` for persistent volume storage and simplified local testing.
- Updated environment variables (`DATABASE_PATH` and `SEED_ON_BOOT`).

## Related Issue
Closes #12

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] My code follows the Go project style guide and best practices  
- [x] I have updated the Dockerfile and Compose configuration  
- [x] I have verified that the container builds and runs locally (`docker-compose up --build`)  
- [x] I have updated README with the correct base image and instructions  

## Implementation Notes
- The app now creates `/app/data/seed/whoknows.db` automatically if missing.  
- Developers can seed data using `SEED_ON_BOOT=1`.  
- Database persistence handled via mounted volume (`./data:/app/data`).

## Screenshots / Logs
N/A (backend change only)

## Reviewers
@gitdengas123456
