### PR TITLE
chore(test): add unit tests for health and search handlers (#80)

### DIFF
--- a/handlers/Healthz_test.go
+++ b/handlers/Healthz_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthz_OK(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	Healthz(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	if body := rec.Body.String(); body != "ok" {
+		t.Fatalf("expected body 'ok', got %q", body)
+	}
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"database/sql"
+	"html/template"
+	"testing"
+
+	"github.com/gorilla/sessions"
+	_ "modernc.org/sqlite"
+)
+
+// setupTestHandlers laver en test-db, templates og session store,
+// og kalder Init, så handlers er klar til brug i tests.
+func setupTestHandlers(t *testing.T) *sql.DB {
+	t.Helper()
+
+	// In-memory SQLite (kun i RAM, forsvinder efter test)
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+
+	// Minimal schema (samme som migrations/0001_create_core_tables.sql)
+	schema := `
+CREATE TABLE IF NOT EXISTS users (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  username  TEXT    NOT NULL UNIQUE,
+  email     TEXT    NOT NULL UNIQUE,
+  password  TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pages (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  title        TEXT    NOT NULL UNIQUE,
+  url          TEXT    NOT NULL UNIQUE,
+  language     TEXT    NOT NULL CHECK(language IN ('en','da')) DEFAULT 'en',
+  last_updated TIMESTAMP,
+  content      TEXT    NOT NULL
+);
+`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	// Enkle templates – bare tekst, ikke rigtige html-filer.
+	tmpl := template.Must(template.New("base").Parse(`
+{{define "search"}}search page {{.Query}}{{end}}
+{{define "search.html"}}search page {{.Query}}{{end}}
+
+{{define "login"}}login page{{end}}
+{{define "login.html"}}login page{{end}}
+
+{{define "register"}}register page{{end}}
+{{define "register.html"}}register page{{end}}
+`))
+
+	// Test session store
+	store := sessions.NewCookieStore([]byte("test-session-key"))
+
+	// Init fra handlers/handlers.go – samme som main gør
+	Init(db, tmpl, store)
+
+	return db
+}

--- a/handlers/search_page_test.go
+++ b/handlers/search_page_test.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearchPageHandler_NoQuery_OK(t *testing.T) {
+	db := setupTestHandlers(t)
+	defer db.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	SearchPageHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if rec.Body.String() == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}
+
+func TestSearchPageHandler_WithQuery_OK(t *testing.T) {
+	db := setupTestHandlers(t)
+	defer db.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/?q=hello&language=en", nil)
+	rec := httptest.NewRecorder()
+
+	SearchPageHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if rec.Body.String() == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}


### PR DESCRIPTION

# chore(test): add handler unit tests for health and search (#80)

---

## Description

This PR introduces the first set of unit tests for the handler layer using Go’s `httptest` package.
The goal is to ensure core endpoints behave correctly in isolation and to improve overall test coverage.

### What was done

* Added in-memory SQLite test setup (`setupTestHandlers`)
* Added minimal test templates (search/login/register)
* Added unit test for `/healthz`
* Added unit tests for `SearchPageHandler` (with and without query)
* Ensures handler logic executes correctly without requiring a running server or real database
* All tests pass with `go test ./...`

### Why this change is needed

This is part of Issue #80 and establishes the foundation for future test coverage across the authentication and API layers.
It ensures core handler behavior is validated and prepares the project for stronger CI guarantees.

---

## Related Issue

Closes **#80**

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] **Chore / test improvement**
* [ ] Documentation update

---

## Checklist

* [x] Code follows Go style guide and project conventions
* [x] Added new tests for handler behavior
* [x] Ran `go fmt`
* [x] Ran `go vet` and confirmed no warnings
* [x] Updated or added necessary helper functions (test setup)
* [x] All tests pass with `go test ./...`

---

## Implementation Notes

* Uses in-memory SQLite (`:memory:`) to avoid filesystem dependencies
* Test templates are simplified to avoid full HTML parsing
* Session store is injected with a test key to allow handler initialization
* All handlers are initialized via `Init(db, tmpl, store)` to match main.go behavior

---

## Reviewers

@Wienerbroed
@Sebkh123
@Frederiknagel

---
