### PR TITLE
feat(search): add FTS5 search path with bm25 ranking + PRAGMA DB tuning

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -4,6 +4,13 @@ import (
 	"net/http"
 )
 
+var useFTSSearch bool
+
+// EnableFTSSearch toggles FTS usage for search endpoints.
+func EnableFTSSearch(on bool) {
+	useFTSSearch = on
+}
+
 // SearchResult represents a single search result row
 type SearchResult struct {
 	ID          int
@@ -57,18 +64,48 @@ func APISearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	var results []SearchResult
 	if q != "" {
-		rows, err := db.Query(
-			`SELECT id, title, url, language, content
+		const limit = 10
+		const offset = 0
+
+		if useFTSSearch {
+			// FTS-powered search when enabled
+			ftsQuery := `
+SELECT p.id,
+       p.title,
+       p.url,
+       p.language,
+       p.content,
+       bm25(pages_fts) AS rank
+FROM pages_fts
+JOIN pages p ON p.id = pages_fts.rowid
+WHERE p.language = ? AND pages_fts MATCH ?
+ORDER BY rank ASC
+LIMIT ? OFFSET ?;`
+			rows, err := db.Query(ftsQuery, language, q, limit, offset)
+			if err == nil {
+				defer func() { _ = rows.Close() }()
+				for rows.Next() {
+					var it SearchResult
+					var rank float64
+					if err := rows.Scan(&it.ID, &it.Title, &it.URL, &it.Language, &it.Description, &rank); err == nil {
+						results = append(results, it)
+					}
+				}
+			}
+		} else {
+			rows, err := db.Query(
+				`SELECT id, title, url, language, content
 			 FROM pages
 			 WHERE language = ? AND (title LIKE ? OR content LIKE ?)`,
-			language, "%"+q+"%", "%"+q+"%",
-		)
-		if err == nil {
-			defer func() { _ = rows.Close() }()
-			for rows.Next() {
-				var it SearchResult
-				if err := rows.Scan(&it.ID, &it.Title, &it.URL, &it.Language, &it.Description); err == nil {
-					results = append(results, it)
+				language, "%"+q+"%", "%"+q+"%",
+			)
+			if err == nil {
+				defer func() { _ = rows.Close() }()
+				for rows.Next() {
+					var it SearchResult
+					if err := rows.Scan(&it.ID, &it.Title, &it.URL, &it.Language, &it.Description); err == nil {
+						results = append(results, it)
+					}
 				}
 			}
 		}

--- a/migrations/0003_pages_fts.sql
+++ b/migrations/0003_pages_fts.sql
@@ -1,0 +1,44 @@
+-- 0003_pages_fts.sql
+-- FTS5 virtual table for full-text search on pages
+
+-- Oprettelse af FTS5-tabel knyttet til pages.id via content='pages' og content_rowid='id'
+CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts
+USING fts5(
+  title,
+  content,
+  url,
+  language,
+  content='pages',
+  content_rowid='id'
+);
+
+-- Seed eksisterende data ind i FTS-tabellen
+INSERT INTO pages_fts(rowid, title, content, url, language)
+SELECT id, title, content, url, language
+FROM pages;
+
+-- Trigger: efter INSERT på pages
+CREATE TRIGGER IF NOT EXISTS pages_ai
+AFTER INSERT ON pages
+BEGIN
+  INSERT INTO pages_fts(rowid, title, content, url, language)
+  VALUES (new.id, new.title, new.content, new.url, new.language);
+END;
+
+-- Trigger: efter UPDATE på pages
+CREATE TRIGGER IF NOT EXISTS pages_au
+AFTER UPDATE ON pages
+BEGIN
+  -- Slet gammel FTS-række
+  DELETE FROM pages_fts WHERE rowid = old.id;
+  -- Indsæt opdateret række
+  INSERT INTO pages_fts(rowid, title, content, url, language)
+  VALUES (new.id, new.title, new.content, new.url, new.language);
+END;
+
+-- Trigger: efter DELETE på pages
+CREATE TRIGGER IF NOT EXISTS pages_ad
+AFTER DELETE ON pages
+BEGIN
+  DELETE FROM pages_fts WHERE rowid = old.id;
+END;


### PR DESCRIPTION
# Pull Request Title
perf(search): add FTS5 search path with bm25 ranking + PRAGMA DB tuning

## Description
This PR implements Phase 2 of the `/api/search` performance work.

**What changes were made?**
- Added a new migration `0003_pages_fts.sql` that:
  - Creates an FTS5 virtual table `pages_fts` linked to `pages.id`.
  - Seeds existing `pages` rows into `pages_fts`.
  - Adds `pages_ai`, `pages_au`, and `pages_ad` triggers to keep `pages_fts` in sync on INSERT/UPDATE/DELETE.
- Extended the application startup (`cmd/server/main.go`) to:
  - Read a new `SEARCH_FTS` environment variable.
  - Apply SQLite PRAGMAs for better concurrency and stability:
    - `PRAGMA journal_mode=WAL;`
    - `PRAGMA synchronous=NORMAL;`
    - `PRAGMA busy_timeout=5000;`
  - Forward the FTS flag to the handlers after initialization.
- Updated the search handlers (`handlers/search.go`) to:
  - Introduce a package-level toggle `EnableFTSSearch(on bool)`.
  - Add an FTS5/MATCH + `bm25`-based branch for `/api/search` with simple `LIMIT/OFFSET` defaults.
  - Fall back to the original `LIKE`-based query when:
    - `SEARCH_FTS` is not set, or
    - the query string is empty.

**Why is this change needed?**
- FTS5 provides faster and more scalable full-text search compared to `%LIKE%`, especially as the `pages` table grows.
- WAL + busy_timeout reduce `database is locked` errors and make the app more robust under concurrent reads/writes.
- The FTS path is fully optional and gated by `SEARCH_FTS=1`, so existing behaviour remains unchanged by default.

**Relevant context**
- Phase 1 (Issue #93) added baseline migrations and the `idx_pages_language` B-tree index.
- This PR builds on that by adding FTS5, PRAGMAs and a feature-flagged FTS search path for the JSON `/api/search` endpoint.

## Related Issue
Closes #96

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [x] Improvement (performance / stability)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update  

## Checklist
- [x] My code follows the Go project style guide and best practices  
- [ ] I have added tests that prove my fix is effective or that my feature works (FTS tests can be added in a follow-up PR)  
- [x] I have run `go fmt` on my code  
- [x] I have run `go vet` and fixed warnings  
- [ ] I have updated any necessary documentation (README, docs, etc.)  
- [x] All new and existing tests pass (`go test ./...`)  

## Implementation Notes
- `SEARCH_FTS` is read in `main.go` and propagated via `handlers.EnableFTSSearch(on bool)`.
- When `SEARCH_FTS=1` and `q` is non-empty, `/api/search`:
  - Queries `pages_fts` using `MATCH ?` and joins back to `pages` on `rowid = id`.
  - Orders results by `bm25(pages_fts)` and applies a simple `LIMIT/OFFSET` (10/0).
- When FTS is disabled or `q` is empty, the handler falls back to the existing `LIKE`-based query, preserving old behaviour.
- FTS errors are treated as “no results” rather than fatal, to keep the API resilient if FTS is misconfigured.
- PRAGMAs are best-effort: failures are logged but do not crash the server, so the app can still run with defaults.

## Screenshots / Logs
_Not applicable – backend behaviour change only. The main observable change is faster `/api/search` when `SEARCH_FTS=1` is enabled._

## Reviewers
@Sebkh123  
@Wienerbroed  
@Frederiknagel
