### PR TITLE
Fix indentation and formatting in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,12 @@ services:
     environment:
       - PORT=8080
       - DATABASE_PATH=/app/data/seed/whoknows.db
-      - SEED_ON_BOOT=1   # Only needed the first time to seed data
+      - SEED_ON_BOOT=1
     volumes:
-      # Mount a local folder to persist database data
       - ./data:/app/data
     restart: unless-stopped
 
-     prometheus:
+  prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
     ports:


### PR DESCRIPTION
This PR corrects the indentation of the prometheus service in docker-compose.yml.
Incorrect indentation previously caused YAML to interpret prometheus: as part of the whoknows-app service, preventing Prometheus and Grafana from starting correctly.