### PR TITLE
test: move handler tests into top-level tests package

### DIFF
--- a/tests/Healthz_test.go
+++ b/tests/Healthz_test.go
@@ -1,16 +1,18 @@
-package handlers
+package tests
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	h "devops-valgfag/handlers"
 )
 
 func TestHealthz_OK(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	rec := httptest.NewRecorder()
 
-	Healthz(rec, req)
+	h.Healthz(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)

--- a/tests/handlers_test.go
+++ b/tests/handlers_test.go
@@ -1,26 +1,26 @@
-package handlers
+package tests
 
 import (
 	"database/sql"
 	"html/template"
 	"testing"
 
+	h "devops-valgfag/handlers"
 	"github.com/gorilla/sessions"
 	_ "modernc.org/sqlite"
 )
 
-// setupTestHandlers laver en test-db, templates og session store,
-// og kalder Init, så handlers er klar til brug i tests.
+// setupTestHandlers creates an in-memory DB, templates, and session store, then wires handlers.Init.
 func setupTestHandlers(t *testing.T) *sql.DB {
 	t.Helper()
 
-	// In-memory SQLite (kun i RAM, forsvinder efter test)
+	// In-memory SQLite (only in RAM; disappears after the test)
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("failed to open in-memory sqlite: %v", err)
 	}
 
-	// Minimal schema (samme som migrations/0001_create_core_tables.sql)
+	// Minimal schema (mirrors migrations/0001_create_core_tables.sql)
 	schema := `
 CREATE TABLE IF NOT EXISTS users (
   id        INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS pages (
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	// Enkle templates – bare tekst, ikke rigtige html-filer.
+	// Simple templates for tests (no real HTML files).
 	tmpl := template.Must(template.New("base").Parse(`
 {{define "search"}}search page {{.Query}}{{end}}
 {{define "search.html"}}search page {{.Query}}{{end}}
@@ -57,8 +57,8 @@ CREATE TABLE IF NOT EXISTS pages (
 	// Test session store
 	store := sessions.NewCookieStore([]byte("test-session-key"))
 
-	// Init fra handlers/handlers.go – samme som main gør
-	Init(db, tmpl, store)
+	// Init from handlers/handlers.go (same as main)
+	h.Init(db, tmpl, store)
 
 	return db
 }

--- a/tests/search_page_test.go
+++ b/tests/search_page_test.go
@@ -1,10 +1,12 @@
-package handlers
+package tests
 
 import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	h "devops-valgfag/handlers"
 )
 
 func closeDB(t *testing.T, db *sql.DB) {
@@ -21,7 +23,7 @@ func TestSearchPageHandler_NoQuery_OK(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 
-	SearchPageHandler(rec, req)
+	h.SearchPageHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)
@@ -38,7 +40,7 @@ func TestSearchPageHandler_WithQuery_OK(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/?q=hello&language=en", nil)
 	rec := httptest.NewRecorder()
 
-	SearchPageHandler(rec, req)
+	h.SearchPageHandler(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)


### PR DESCRIPTION
# Pull Request Title

**test: move handler tests into top-level tests package**

## Description

This PR restructures the project’s test layout by moving all handler-related tests from the `handlers/` package into a dedicated top-level `tests/` package.

* Added new test files under `tests/` (`Healthz_test.go`, `handlers_test.go`, `search_page_test.go`, and integration tests).
* Removed the old `_test.go` files from `handlers/`.
* Ensured all test files now use a consistent `package tests`.
* Updated imports to reference `devops-valgfag/handlers` correctly.

**Why this change is needed:**

* Fixes the Go compiler error: *“found packages handlers and tests in /tests”*
* Aligns project with Go best practices for black-box testing.
* Prevents future package-name mismatches and improves maintainability.

**Context:**
Only structural test cleanup. No application logic, monitoring config, or documentation changed.

## Related Issue

*No issue number – structural cleanup only.*

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (changes existing functionality)
* [x] Documentation/update to test layout

## Checklist

* [x] My code follows the Go project style guide and best practices
* [x] I have added tests that prove my fix is effective (tests already existed, only moved)
* [x] I have run `go fmt` on my code
* [x] I have run `go vet` and fixed warnings
* [x] I have updated test imports where necessary
* [x] All new and existing tests pass (`go test ./...`)

## Implementation Notes

* No functional changes to handlers.
* No config/env/db/template changes.
* This PR strictly reorganizes test files into a new package.


