### PR TITLE
Fix hero bleed + cloud edge overlap (CSS spacing adjustments)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -84,6 +84,9 @@ body{
 
 /* Content spacing */
 .content{padding:28px 0 64px}
+.content > .hero-bleed:first-child{
+  margin-top:-28px; /* pull hero up to touch the header */
+}
 
 /* ===== Full-bleed HERO (blue sky + clouds) ===== */
 .hero-bleed{
@@ -93,9 +96,11 @@ body{
   width: 100vw;
   overflow: hidden;
   background: #a7c7ff; /* sky */
-  border-bottom: 1px solid var(--hairline);
 }
-.clouds{ position: absolute; inset: 0; z-index: 1; }
+.clouds{
+  position: absolute; inset: 0; z-index: 1;
+  bottom: -12px; /* let clouds hang past bottom to avoid showing the edge */
+}
 .cloud{
   position: absolute; top: 0; left: 0;
   width: 200%; height: 100%;


### PR DESCRIPTION
# Pull Request Title  
Fix hero bleed + cloud overlap (CSS spacing refinement)

## Description
Denne PR justerer styling af “hero bleed” sektionen for at forbedre visuel konsistens og undgå at sky/cloud-grafikken klipper mod kanten.

**Hvad er ændret?**
- Fjernet `border-bottom` som gav en hård kant under hero-sektionen.  
- Justeret `.content` spacing for at trække hero-sektionen tættere på headeren.  
- Tilføjet `bottom: -12px` til `.clouds` så sky-elementet hænger korrekt uden visuelle artefakter.

**Hvorfor er ændringen nødvendig?**
- Gammel styling gav et visuelt “cutoff”, især i full-bleed views.  
- Cloud-lagets tidligere position afslørede bottom edge ved scroll.  
- Giver et mere professionelt, rent look.

**Relevant kontekst**
- Kun UI/CSS påvirkes.  
- Ingen ændringer til Go/backend.

## Related Issue
Closes #ISSUE_NUMBER (hvis relevant)

## Type of Change
- [x] UI/Styling fix (non-breaking)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] CSS valideret manuelt i browser  
- [x] Ingen funktionelle ændringer til backend  
- [x] Ingen side-effekter på øvrigt layout  
- [ ] Responsiv visning testet (mobile/tablet)  
- [x] Alle eksisterende tests passer (`go test ./...`)

## Implementation Notes
- Ændringer kun i CSS-filer.  
- Spacing-justeringer er idempotente og påvirker kun hero-sektionen.  
- Ingen ændring i markup eller templates.

