### PR TITLE
Set SESSION_KEY for CI server startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Start server
         env:
           DATABASE_URL: postgres://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}?sslmode=disable
+          SESSION_KEY: "ci-test-session-key"
         run: |
           nohup ./server > app.log 2>&1 &
           echo $! > app.pid


### PR DESCRIPTION
Add SESSION_KEY environment variable for CI server.

CI is failing because SESSION_KEY isrequired at startup.
In our GitHub Action, the server starts without a SESSION_KEY, so it immediately crashes with log.Fatal("SESSION_KEY is required") before the health check runs.
The fix is simply to add a dummy SESSION_KEY in the workflow’s “Start server” step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI health check workflow configuration to enhance testing environment setup.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal CI/CD infrastructure improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->