### PR TITLE
Modify FTS query to include 'simple' argument

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -168,7 +168,7 @@ func APISearchHandler(w http.ResponseWriter, r *http.Request) {
 		if useFTSSearch {
 			// Use a CTE so plainto_tsquery($2) is parsed only once.
 			ftsQuery := `
-				WITH q AS (SELECT plainto_tsquery($2) AS query)
+				WITH q AS (SELECT plainto_tsquery('simple', $2) AS query)
 				SELECT id, title, url, language, content
 				FROM pages, q
 				WHERE language = $1


### PR DESCRIPTION
Updated the plainto_tsquery function to use 'simple' as the first argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-text search query parsing for more accurate search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->